### PR TITLE
Add stylelint as an alternate CSS linter. 

### DIFF
--- a/pre-commit/2-css-style-csslint.sh
+++ b/pre-commit/2-css-style-csslint.sh
@@ -11,7 +11,7 @@ function test_file {
   fi
 
   if which -s csslint ; then
-    echo "Running CSS style lint..."
+    echo "Running CSS style lint with csslint..."
 
     # Set -e before and +e after for _required_ linters (i.e.: that will prevent
     # commit, e.g.: syntax linters).
@@ -27,7 +27,7 @@ function test_file {
 
 case "${1}" in
   --about )
-    echo "CSS style lint."
+    echo "CSS style lint (with csslint)."
     ;;
 
   * )

--- a/pre-commit/2-css-style-stylelint.sh
+++ b/pre-commit/2-css-style-stylelint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034
+GREP_OPTIONS=""
+
+function test_file {
+  file="${1}"
+
+  if [ ! -f "${file}" ] ; then
+    return
+  fi
+
+  if which -s stylelint ; then
+    echo "Running CSS style lint with stylelint..."
+
+    # Set -e before and +e after for _required_ linters (i.e.: that will prevent
+    # commit, e.g.: syntax linters).
+    # Set +e before and -e after for _optional_ linters (i.e.: that will only
+    # output messages upon commit, e.g.: style linters).
+    set +e
+    stylelint "$file"
+    set -e
+  else
+    echo "Can't run the CSS style linter because the stylelint executable isn't in the PATH."
+  fi
+}
+
+case "${1}" in
+  --about )
+    echo "CSS style lint (with stylelint)."
+    ;;
+
+  * )
+    for file in $(git diff-index --cached --name-only HEAD | grep -E '\.(css)') ; do
+      test_file "${file}"
+    done
+    ;;
+esac


### PR DESCRIPTION
Inspired by [Clean CSS with Stylelint](https://dri.es/clean-css-with-stylelint) by @dbuytaert.

Note the linter added in this pull request assumes some changes from the configuration presented in the post above:

In order for stylelint to pick up its configuration automatically, I had to:

1. Rename the configuration file from `stylelint.js` to `.stylelintrc`,
2. Remove the `'use strict'` statement at the beginning of the file, and,
3. Remove the `module.exports = ` assignment before the JSON settings array.

In order for stylelint to work with the configuration file, but not require the --config-basedir argument, I had to:

1. Install stylelint-config-standard and stylelint-no-browser-hacks locally, i.e.:

        npm install stylelint-config-standard stylelint-no-browser-hacks
